### PR TITLE
Fix SetAlign for last column: it did nothing.

### DIFF
--- a/table.go
+++ b/table.go
@@ -184,7 +184,7 @@ func (t *Table) SetAlign(align tableAlignment, column int) {
 		if !ok {
 			continue
 		}
-		if column >= len(row.cells) {
+		if column > len(row.cells) {
 			continue
 		}
 		row.cells[column-1].alignment = &align

--- a/table_test.go
+++ b/table_test.go
@@ -381,10 +381,10 @@ func TestTableAlignPostsetting(t *testing.T) {
 		"+-----------+-------+\n" +
 		"| Name      | Value |\n" +
 		"+-----------+-------+\n" +
-		"|       hey | you   |\n" +
-		"|       ken | 1234  |\n" +
-		"|     derek | 3.14  |\n" +
-		"| derek too | 3.15  |\n" +
+		"|       hey |   you |\n" +
+		"|       ken |  1234 |\n" +
+		"|     derek |  3.14 |\n" +
+		"| derek too |  3.15 |\n" +
 		"|  escaping | rox%% |\n" +
 		"+-----------+-------+\n"
 
@@ -398,6 +398,7 @@ func TestTableAlignPostsetting(t *testing.T) {
 	table.AddRow("escaping", "rox%%")
 
 	table.SetAlign(AlignRight, 1)
+	table.SetAlign(AlignRight, 2)
 
 	checkRendersTo(t, table, expected)
 }


### PR DESCRIPTION
Due to off-by-one defect in the code, it wasn't possible to use SetAlign for the last column in the table as it was always simply ignored.